### PR TITLE
Fix About section styling

### DIFF
--- a/src/components/About.js
+++ b/src/components/About.js
@@ -4,7 +4,7 @@ import styles from './About.module.css'
 
 function About() {
   return (
-    <section id="about" className='about' style={styles}>
+    <section id="about" className={styles.about}>
       <h1>/ about me</h1>
       <p>
         Hi, I'm  David, a software engineer currently working at Tracknamic. Currently learning React.js. Here are some technologies I have been working with:

--- a/src/components/About.module.css
+++ b/src/components/About.module.css
@@ -1,3 +1,7 @@
+.about {
+    /* Add any about section specific styling here */
+}
+
 .about ul li {
     display: inline;
     margin: 0 10px;


### PR DESCRIPTION
## Summary
- use CSS module class instead of inline style in `About.js`
- add `.about` selector to CSS module

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6b075e28832090d3e4fa6fc86993