### PR TITLE
Fix Footer styles import

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import './Footer.module.css'; // Importing the CSS for the footer
+import styles from './Footer.module.css';
 
 function Footer() {
     return (
         <>
         <section id="footer">
-            <footer className="footer">
+            <footer className={styles.footer}>
                 <p>Built and designed by David Boros.</p>
                 <p> All rights reserved. ©</p>
             </footer>


### PR DESCRIPTION
## Summary
- use CSS module import in `Footer`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6b0ef1248320898efa26dd76ec95