### PR TITLE
Fix star animations and default sizes

### DIFF
--- a/src/components/Stars.css
+++ b/src/components/Stars.css
@@ -13,8 +13,9 @@
     position: absolute;
     background: white; /* Star color */
     border-radius: 50%; /* Make them circular */
-    animation: twinkle 1.5s infinite; /* Animation for twinkling */
-    animation: move 10s linear infinite; /* Animation for moving */
+    width: 2px;
+    height: 2px;
+    animation: twinkle 1.5s infinite, move 10s linear infinite; /* Combined animations */
 }
 
 /* Position the stars randomly and give them random sizes */


### PR DESCRIPTION
## Summary
- merge animations into a single line
- provide default size for star elements

## Testing
- `npm test --silent -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b6b1624bc832097bdd12691a4a7a3